### PR TITLE
Equals fix

### DIFF
--- a/src/main/antlr/LibSLLexer.g4
+++ b/src/main/antlr/LibSLLexer.g4
@@ -4,7 +4,9 @@ lexer grammar LibSLLexer;
 
 SEMICOLON : ';' ;
 
-EQ : '=' ;
+ASSIGN_OP : '=' ;
+
+EQ : '==' ;
 
 L_BRACE : '{' ;
 

--- a/src/main/antlr/LibSLParser.g4
+++ b/src/main/antlr/LibSLParser.g4
@@ -271,7 +271,7 @@ expression
    |   expression op=(PLUS | MINUS) expression
    |   op=MINUS expression
    |   op=EXCLAMATION expression
-   |   expression op=(ASSIGN_OP | EQ | NOT_EQ | LESS_EQ | L_ARROW | GREAT_EQ | R_ARROW) expression
+   |   expression op=(EQ | NOT_EQ | LESS_EQ | L_ARROW | GREAT_EQ | R_ARROW) expression
    |   expression op=(AND | OR | XOR) expression
    |   qualifiedAccess apostrophe=APOSTROPHE
    |   expressionAtomic

--- a/src/main/antlr/LibSLParser.g4
+++ b/src/main/antlr/LibSLParser.g4
@@ -48,7 +48,7 @@ header:
  * syntax: typealias name = origintlType
  */
 typealiasStatement
-   :   TYPEALIAS left=typeIdentifier EQ right=typeIdentifier SEMICOLON
+   :   TYPEALIAS left=typeIdentifier ASSIGN_OP right=typeIdentifier SEMICOLON
    ;
 
 /* type define block
@@ -70,7 +70,7 @@ enumBlock
    ;
 
 enumBlockStatement
-   :   Identifier EQ integerNumber SEMICOLON
+   :   Identifier ASSIGN_OP integerNumber SEMICOLON
    ;
 
 /* semantic types section
@@ -146,7 +146,7 @@ functionsListPart
  */
 variableDecl
    :   VAR nameWithType SEMICOLON
-   |   VAR nameWithType EQ assignmentRight SEMICOLON
+   |   VAR nameWithType ASSIGN_OP assignmentRight SEMICOLON
    ;
 
 nameWithType
@@ -161,7 +161,7 @@ typeIdentifier
    ;
 
 variableAssignment
-   :   qualifiedAccess EQ assignmentRight SEMICOLON
+   :   qualifiedAccess ASSIGN_OP assignmentRight SEMICOLON
    ;
 
 assignmentRight
@@ -178,8 +178,8 @@ namedArgs
    ;
 
 argPair
-   :   name=STATE EQ expressionAtomic
-   |   name=Identifier EQ expression
+   :   name=STATE ASSIGN_OP expressionAtomic
+   |   name=Identifier ASSIGN_OP expression
    ;
 
 /*

--- a/src/main/antlr/LibSLParser.g4
+++ b/src/main/antlr/LibSLParser.g4
@@ -271,7 +271,7 @@ expression
    |   expression op=(PLUS | MINUS) expression
    |   op=MINUS expression
    |   op=EXCLAMATION expression
-   |   expression op=(EQ | NOT_EQ | LESS_EQ | L_ARROW | GREAT_EQ | R_ARROW) expression
+   |   expression op=(ASSIGN_OP | EQ | NOT_EQ | LESS_EQ | L_ARROW | GREAT_EQ | R_ARROW) expression
    |   expression op=(AND | OR | XOR) expression
    |   qualifiedAccess apostrophe=APOSTROPHE
    |   expressionAtomic

--- a/src/main/kotlin/org/jetbrains/research/libsl/nodes/expressions.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/nodes/expressions.kt
@@ -15,7 +15,7 @@ data class BinaryOpExpression(
 
 enum class ArithmeticBinaryOps(val string: String) {
     ADD("+"), SUB("-"), MUL("*"), DIV("/"), AND("&"),
-    OR("|"), XOR("^"), MOD("%"), EQ("="), NOT_EQ("!="), GT(">"),
+    OR("|"), XOR("^"), MOD("%"), ASSIGN_OP("="), EQ("=="), NOT_EQ("!="), GT(">"),
     GT_EQ(">="), LT("<"), LT_EQ("<=");
     companion object {
         fun fromString(str: String) = ArithmeticBinaryOps.values().first { op -> op.string == str }

--- a/src/test/kotlin/GeneratedTests.kt
+++ b/src/test/kotlin/GeneratedTests.kt
@@ -51,6 +51,11 @@ class GeneratedTests {
     }
 
     @Test
+    fun testEqualsAndAssignLsl() {
+        runLslTest("equalsAndAssign")
+    }
+
+    @Test
     fun testEscapingTestLsl() {
         runLslTest("escapingTest")
     }

--- a/src/test/testdata/expected/lsl/contracts.lsl
+++ b/src/test/testdata/expected/lsl/contracts.lsl
@@ -1,15 +1,13 @@
 libsl "1.0.0";
 library simple;
-
 types {
     Int(int32);
 }
 automaton A : Int {
     var i: Int;
-    
     fun f(param: Int): Int
         requires test1: (param >= i);
-        ensures ((param' < param) & (result = 1));
+        ensures ((param' < param) & (result == 1));
     {
     }
 }

--- a/src/test/testdata/expected/lsl/equalsAndAssign.lsl
+++ b/src/test/testdata/expected/lsl/equalsAndAssign.lsl
@@ -1,0 +1,9 @@
+libsl "1.0.0";
+library simple;
+typealias Int = int32;
+typealias boolean = bool;
+automaton A : Int {
+    fun foo(x: Int, y: Int): boolean {
+        result = (x == y);
+    }
+}

--- a/src/test/testdata/expected/lsl/variableResolution.lsl
+++ b/src/test/testdata/expected/lsl/variableResolution.lsl
@@ -1,22 +1,18 @@
 libsl "1.0.0";
 library simple;
-
 types {
     Int(int32);
 }
 automaton A : Int {
     var i: Int;
-    
     fun f(param: Int)
-        requires (i = 0);
+        requires (i == 0);
     {
         i = 1;
     }
-    
     fun g(a: Int) {
         i = a;
     }
-    
     fun a(i: Int) {
         i = 0;
     }

--- a/src/test/testdata/lsl/contracts.lsl
+++ b/src/test/testdata/lsl/contracts.lsl
@@ -10,7 +10,7 @@ automaton A : Int {
 
     fun f(param: Int): Int
     requires test1: param >= i;
-    ensures param' < param & result = 1;
+    ensures param' < param & result == 1;
     {
 
     }

--- a/src/test/testdata/lsl/equalsAndAssign.lsl
+++ b/src/test/testdata/lsl/equalsAndAssign.lsl
@@ -1,0 +1,11 @@
+libsl "1.0.0";
+library simple;
+
+typealias Int=int32;
+typealias boolean=bool;
+
+automaton A : Int {
+    fun foo(x: Int, y: Int): boolean {
+        result = x == y;
+    }
+}

--- a/src/test/testdata/lsl/variableResolution.lsl
+++ b/src/test/testdata/lsl/variableResolution.lsl
@@ -9,7 +9,7 @@ automaton A : Int {
     var i: Int;
 
     fun f(param: Int)
-    requires i = 0;
+    requires i == 0;
     {
         i = 1;
     }


### PR DESCRIPTION
1. Assignment operator (`=`)  was fixed (now it can't be used for comparsions). 
2. Equals operator (`==`)  was added for comparisons.
3. Operators were tested in `equalsAndAssign.lsl` file.