### PR TITLE
Literal arrays

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,10 +147,10 @@ There are some utilities to improve an expression experience:
 #### 4.1. [ExpressionVisitor](src/main/kotlin/org/jetbrains/research/libsl/nodes/ExpressionVisitor.kt)
 This class could be used to visit expressions.
 
-#### 4.2 [TypeInferer](src/main/kotlin/org/jetbrains/research/libsl/type/TypeInferer.kt)
+#### 4.2 [TypeInferrer](src/main/kotlin/org/jetbrains/research/libsl/type/TypeInferrer.kt)
 This class could be used to simple type resolution. Example:
 ```kotlin
-context.typeInferer.getExpressionTypeOrNull(myExpression)
+context.typeInferrer.getExpressionTypeOrNull(myExpression)
 ```
 
 IMPORTANT: this class does simple type resolution. So, type of `1 + (2*4)` is `IntType`, but type of `1 + 1.0` can't be

--- a/src/main/antlr/LibSLParser.g4
+++ b/src/main/antlr/LibSLParser.g4
@@ -204,7 +204,7 @@ parameter
  * syntax: @annotationName(args)
  */
 annotation
-   :   AT Identifier (L_BRACKET argsList R_BRACKET)?
+   :   AT Identifier (L_BRACKET expressionsList R_BRACKET)?
    ;
 
 /*
@@ -233,10 +233,10 @@ functionBodyStatements
  * syntax: action ActionName(args)
  */
 action
-   :  ACTION Identifier L_BRACKET argsList R_BRACKET SEMICOLON
+   :  ACTION Identifier L_BRACKET expressionsList R_BRACKET SEMICOLON
    ;
 
-argsList
+expressionsList
    :   expression (COMMA expression)*
    ;
 

--- a/src/main/antlr/LibSLParser.g4
+++ b/src/main/antlr/LibSLParser.g4
@@ -306,7 +306,7 @@ identifierList
    ;
 
 arrayLiteral
-   :   L_SQUARE_BRACKET expressionsList R_SQUARE_BRACKET
+   :   L_SQUARE_BRACKET expressionsList? R_SQUARE_BRACKET
    ;
 
 periodSeparatedFullName

--- a/src/main/antlr/LibSLParser.g4
+++ b/src/main/antlr/LibSLParser.g4
@@ -281,6 +281,7 @@ expression
 expressionAtomic
    :   qualifiedAccess
    |   primitiveLiteral
+   |   arrayLiteral
    ;
 
 primitiveLiteral
@@ -302,6 +303,10 @@ simpleCall
 
 identifierList
    :   Identifier (COMMA Identifier)*
+   ;
+
+arrayLiteral
+   :   L_SQUARE_BRACKET expressionsList R_SQUARE_BRACKET
    ;
 
 periodSeparatedFullName

--- a/src/main/antlr/LibSLParser.g4
+++ b/src/main/antlr/LibSLParser.g4
@@ -237,7 +237,7 @@ action
    ;
 
 expressionsList
-   :   expression (COMMA expression)*
+   :   expression (COMMA expression)* COMMA?
    ;
 
 /* requires contract

--- a/src/main/kotlin/org/jetbrains/research/libsl/context/LslContextBase.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/context/LslContextBase.kt
@@ -9,7 +9,7 @@ import org.jetbrains.research.libsl.nodes.references.TypeReference
 import org.jetbrains.research.libsl.nodes.references.VariableReference
 import org.jetbrains.research.libsl.type.RealType
 import org.jetbrains.research.libsl.type.Type
-import org.jetbrains.research.libsl.type.TypeInferer
+import org.jetbrains.research.libsl.type.TypeInferrer
 
 abstract class LslContextBase {
     abstract val parentContext: LslContextBase?
@@ -20,7 +20,7 @@ abstract class LslContextBase {
     private val variables = mutableListOf<Variable>()
 
     @Suppress("LeakingThis")
-    val typeInferer = TypeInferer(this)
+    val typeInferrer = TypeInferrer(this)
 
     fun storeAutomata(automaton: Automaton) {
         automata.add(automaton)

--- a/src/main/kotlin/org/jetbrains/research/libsl/context/LslGlobalContext.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/context/LslGlobalContext.kt
@@ -8,7 +8,6 @@ import org.jetbrains.research.libsl.nodes.references.FunctionReference
 import org.jetbrains.research.libsl.nodes.references.TypeReference
 import org.jetbrains.research.libsl.nodes.references.VariableReference
 import org.jetbrains.research.libsl.type.*
-import java.util.Objects
 
 class LslGlobalContext : LslContextBase() {
     @Suppress("MemberVisibilityCanBePrivate")
@@ -40,6 +39,8 @@ class LslGlobalContext : LslContextBase() {
                 add(CharType(this@LslGlobalContext, pointer))
                 add(StringType(this@LslGlobalContext, pointer))
                 add(VoidType(this@LslGlobalContext, pointer))
+
+                add(AnyType(this@LslGlobalContext))
             }
         }
 

--- a/src/main/kotlin/org/jetbrains/research/libsl/context/LslGlobalContext.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/context/LslGlobalContext.kt
@@ -41,6 +41,7 @@ class LslGlobalContext : LslContextBase() {
                 add(VoidType(this@LslGlobalContext, pointer))
 
                 add(AnyType(this@LslGlobalContext))
+                add(NothingType(this@LslGlobalContext))
             }
         }
 

--- a/src/main/kotlin/org/jetbrains/research/libsl/nodes/ExpressionVisitor.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/nodes/ExpressionVisitor.kt
@@ -18,6 +18,7 @@ abstract class ExpressionVisitor <T> {
             is FunctionArgument -> visitFunctionArgument(node)
             is ResultVariable -> visitResultVariable(node)
             is Variable -> visitVariable(node)
+            is ArrayLiteral -> visitArrayLiteral(node)
         }
     }
 
@@ -50,4 +51,6 @@ abstract class ExpressionVisitor <T> {
     abstract fun visitResultVariable(node: ResultVariable): T
 
     abstract fun visitVariable(node: Variable): T
+
+    abstract fun visitArrayLiteral(node: ArrayLiteral): T
 }

--- a/src/main/kotlin/org/jetbrains/research/libsl/nodes/expressions.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/nodes/expressions.kt
@@ -57,6 +57,20 @@ data class CallAutomatonConstructor(
     }
 }
 
+data class ArrayLiteral(
+    override val value: List<Expression>
+) : Atomic() {
+    override fun dumpToString(): String {
+        return buildString {
+            append("[")
+            append(
+                value.joinToString(separator = ", ") { v -> v.dumpToString() }
+            )
+            append("]")
+        }
+    }
+}
+
 sealed class Atomic : Expression() {
     abstract val value: Any?
 

--- a/src/main/kotlin/org/jetbrains/research/libsl/type/PrimitiveTypes.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/type/PrimitiveTypes.kt
@@ -2,6 +2,7 @@ package org.jetbrains.research.libsl.type
 
 import org.jetbrains.research.libsl.context.LslContextBase
 import org.jetbrains.research.libsl.nodes.references.TypeReference
+import org.jetbrains.research.libsl.nodes.references.builders.TypeReferenceBuilder
 
 interface PrimitiveType : Type {
     override fun dumpToString(): String {
@@ -78,4 +79,20 @@ data class VoidType(
 ) : PrimitiveType {
     override val name: String = "void"
     override val generic: TypeReference? = null
+}
+
+data class AnyType(
+    override val context: LslContextBase
+) : PrimitiveType {
+    override val name: String = ANY_TYPE_NAME
+    override val isPointer: Boolean = false
+    override val generic: TypeReference? = null
+
+    companion object {
+        const val ANY_TYPE_NAME = "any"
+
+        fun getAnyTypeReference(context: LslContextBase): TypeReference{
+            return TypeReferenceBuilder.build(ANY_TYPE_NAME, genericReference = null, isPointer = false, context)
+        }
+    }
 }

--- a/src/main/kotlin/org/jetbrains/research/libsl/type/PrimitiveTypes.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/type/PrimitiveTypes.kt
@@ -96,3 +96,19 @@ data class AnyType(
         }
     }
 }
+
+data class NothingType(
+    override val context: LslContextBase
+) : PrimitiveType {
+    override val name: String = Nothing_TYPE_NAME
+    override val isPointer: Boolean = false
+    override val generic: TypeReference? = null
+
+    companion object {
+        const val Nothing_TYPE_NAME = "nothing"
+
+        fun getNothingTypeReference(context: LslContextBase): TypeReference{
+            return TypeReferenceBuilder.build(Nothing_TYPE_NAME, genericReference = null, isPointer = false, context)
+        }
+    }
+}

--- a/src/main/kotlin/org/jetbrains/research/libsl/type/TypeInferer.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/type/TypeInferer.kt
@@ -2,6 +2,7 @@ package org.jetbrains.research.libsl.type
 
 import org.jetbrains.research.libsl.context.LslContextBase
 import org.jetbrains.research.libsl.nodes.*
+import org.jetbrains.research.libsl.nodes.references.builders.TypeReferenceBuilder.getReference
 
 class TypeInferer(private val context: LslContextBase) {
     private val anyType by lazy { context.resolveType(AnyType.getAnyTypeReference(context))!! }
@@ -50,9 +51,15 @@ class TypeInferer(private val context: LslContextBase) {
     }
 
     private fun getArrayLiteralType(arrayLiteral: ArrayLiteral): Type {
-        return arrayLiteral.value.fold(anyType) { acc, expression ->
+        val typeOfElements = arrayLiteral.value.fold(anyType) { acc, expression ->
             mergeTypes(acc, getExpressionType(expression))
         }
+
+        return ArrayType(
+            isPointer = false,
+            generic = typeOfElements.getReference(context),
+            context = context
+        )
     }
 
     fun mergeTypesOrNull(typeA: Type, typeB: Type): Type? {

--- a/src/main/kotlin/org/jetbrains/research/libsl/type/TypeInferrer.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/type/TypeInferrer.kt
@@ -4,7 +4,7 @@ import org.jetbrains.research.libsl.context.LslContextBase
 import org.jetbrains.research.libsl.nodes.*
 import org.jetbrains.research.libsl.nodes.references.builders.TypeReferenceBuilder.getReference
 
-class TypeInferer(private val context: LslContextBase) {
+class TypeInferrer(private val context: LslContextBase) {
     private val anyType by lazy { context.resolveType(AnyType.getAnyTypeReference(context))!! }
 
     @Suppress("MemberVisibilityCanBePrivate", "unused")

--- a/src/main/kotlin/org/jetbrains/research/libsl/type/TypeInferrer.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/type/TypeInferrer.kt
@@ -6,6 +6,7 @@ import org.jetbrains.research.libsl.nodes.references.builders.TypeReferenceBuild
 
 class TypeInferrer(private val context: LslContextBase) {
     private val anyType by lazy { context.resolveType(AnyType.getAnyTypeReference(context))!! }
+    private val nothingType by lazy { context.resolveType(NothingType.getNothingTypeReference(context))!! }
 
     @Suppress("MemberVisibilityCanBePrivate", "unused")
     fun getExpressionTypeOrNull(expression: Expression): Type? {
@@ -51,7 +52,7 @@ class TypeInferrer(private val context: LslContextBase) {
     }
 
     private fun getArrayLiteralType(arrayLiteral: ArrayLiteral): Type {
-        val typeOfElements = arrayLiteral.value.fold(anyType) { acc, expression ->
+        val typeOfElements = arrayLiteral.value.fold(nothingType) { acc, expression ->
             mergeTypes(acc, getExpressionType(expression))
         }
 
@@ -88,6 +89,14 @@ class TypeInferrer(private val context: LslContextBase) {
         }
 
         if (typeA::class == typeB::class) {
+            return typeA
+        }
+
+        if (typeA is NothingType) {
+            return typeB
+        }
+
+        if (typeB is NothingType) {
             return typeA
         }
 

--- a/src/main/kotlin/org/jetbrains/research/libsl/visitors/ExpressionVisitor.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/visitors/ExpressionVisitor.kt
@@ -164,7 +164,7 @@ class ExpressionVisitor(
 
     override fun visitArrayLiteral(ctx: ArrayLiteralContext): Atomic {
         val arrayValues = mutableListOf<Expression>()
-        for (value in ctx.expressionsList().expression()) {
+        for (value in ctx.expressionsList()?.expression() ?: listOf()) {
             arrayValues.add(visitExpression(value))
         }
 

--- a/src/main/kotlin/org/jetbrains/research/libsl/visitors/ExpressionVisitor.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/visitors/ExpressionVisitor.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.research.libsl.visitors
 
 import org.jetbrains.research.libsl.LibSLParser
+import org.jetbrains.research.libsl.LibSLParser.ArrayLiteralContext
 import org.jetbrains.research.libsl.LibSLParser.ExpressionContext
 import org.jetbrains.research.libsl.LibSLParser.PeriodSeparatedFullNameContext
 import org.jetbrains.research.libsl.LibSLParser.QualifiedAccessContext
@@ -93,6 +94,10 @@ class ExpressionVisitor(
                 visitQualifiedAccess(ctx.qualifiedAccess())
             }
 
+            ctx.arrayLiteral() != null -> {
+                visitArrayLiteral(ctx.arrayLiteral())
+            }
+
             else -> error("unknown expression kind")
         }
     }
@@ -155,6 +160,17 @@ class ExpressionVisitor(
 
             else -> error("unknown qualified access kind")
         }
+    }
+
+    override fun visitArrayLiteral(ctx: ArrayLiteralContext): Atomic {
+        val arrayValues = mutableListOf<Expression>()
+        for (value in ctx.expressionsList().expression()) {
+            arrayValues.add(visitExpression(value))
+        }
+
+        return ArrayLiteral(
+            value = arrayValues
+        )
     }
 
     private fun processPeriodSeparatedQualifiedAccess(

--- a/src/main/kotlin/org/jetbrains/research/libsl/visitors/FunctionVisitor.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/visitors/FunctionVisitor.kt
@@ -90,7 +90,7 @@ class FunctionVisitor(
 
         val name = ctx.Identifier().asPeriodSeparatedString()
         val expressionVisitor = ExpressionVisitor(functionContext)
-        val args = ctx.argsList()?.expression()?.map { expr ->
+        val args = ctx.expressionsList()?.expression()?.map { expr ->
             expressionVisitor.visitExpression(expr)
         }.orEmpty().toMutableList()
 
@@ -140,7 +140,7 @@ class FunctionVisitor(
     override fun visitAction(ctx: LibSLParser.ActionContext) {
         val name = ctx.Identifier().text.extractIdentifier()
         val expressionVisitor = ExpressionVisitor(functionContext)
-        val args = ctx.argsList().expression().map { expr ->
+        val args = ctx.expressionsList().expression().map { expr ->
             expressionVisitor.visitExpression(expr)
         }.toMutableList()
 

--- a/src/test/kotlin/GeneratedTests.kt
+++ b/src/test/kotlin/GeneratedTests.kt
@@ -66,6 +66,11 @@ class GeneratedTests {
     }
 
     @Test
+    fun testLiteralArraysLsl() {
+        runLslTest("literalArrays")
+    }
+
+    @Test
     fun testMultipleFromInShiftLsl() {
         runLslTest("multipleFromInShift")
     }

--- a/src/test/kotlin/testRunner.kt
+++ b/src/test/kotlin/testRunner.kt
@@ -106,8 +106,8 @@ private fun checkFunctionIsResolved(function: Function) {
         when (statement) {
             is Action -> {}
             is Assignment -> {
-                function.context.typeInferer.getExpressionType(statement.left)
-                function.context.typeInferer.getExpressionType(statement.value)
+                function.context.typeInferrer.getExpressionType(statement.left)
+                function.context.typeInferrer.getExpressionType(statement.value)
             }
         }
     }

--- a/src/test/testdata/expected/lsl/literalArrays.lsl
+++ b/src/test/testdata/expected/lsl/literalArrays.lsl
@@ -1,7 +1,9 @@
 libsl "1.0.0";
 library literalArrays;
 typealias Int = int32;
+typealias ArrayType = array<Int>;
 automaton A : Int {
+    var arrayVariable: ArrayType;
     fun f(param: Int) {
         action TEST_ACTION([123]);
         action TEST_ACTION([123]);
@@ -10,5 +12,9 @@ automaton A : Int {
         action TEST_ACTION(["test string", param]);
         action TEST_ACTION([]);
         action TEST_ACTION([((1 + 2) + 3)]);
+    }
+    fun g() {
+        arrayVariable = [1, "2", "null"];
+        arrayVariable = [1, 2, 3];
     }
 }

--- a/src/test/testdata/expected/lsl/literalArrays.lsl
+++ b/src/test/testdata/expected/lsl/literalArrays.lsl
@@ -14,7 +14,7 @@ automaton A : Int {
         action TEST_ACTION([((1 + 2) + 3)]);
     }
     fun g() {
-        arrayVariable = [1, "2", "null"];
+        arrayVariable = ["1", "2", "null"];
         arrayVariable = [1, 2, 3];
     }
 }

--- a/src/test/testdata/expected/lsl/literalArrays.lsl
+++ b/src/test/testdata/expected/lsl/literalArrays.lsl
@@ -1,0 +1,14 @@
+libsl "1.0.0";
+library literalArrays;
+typealias Int = int32;
+automaton A : Int {
+    fun f(param: Int) {
+        action TEST_ACTION([123]);
+        action TEST_ACTION([123]);
+        action TEST_ACTION([123, 321]);
+        action TEST_ACTION(["test string", param]);
+        action TEST_ACTION(["test string", param]);
+        action TEST_ACTION([]);
+        action TEST_ACTION([((1 + 2) + 3)]);
+    }
+}

--- a/src/test/testdata/lsl/literalArrays.lsl
+++ b/src/test/testdata/lsl/literalArrays.lsl
@@ -18,7 +18,7 @@ automaton A : Int {
     }
 
     fun g() {
-        arrayVariable = [1, "2", "null", ]; // the literal list has an `array<any>` type
+        arrayVariable = ["1", "2", "null", ]; // the literal list has an `array<any>` type
         arrayVariable = [1, 2, 3]; // the literal list has an `array<int>` type
     }
 }

--- a/src/test/testdata/lsl/literalArrays.lsl
+++ b/src/test/testdata/lsl/literalArrays.lsl
@@ -18,7 +18,7 @@ automaton A : Int {
     }
 
     fun g() {
-        arrayVariable = [1, "2", "null", ]; // the literal list has an `any` type
-        arrayVariable = [1, 2, 3]; // the literal list has an `int` type
+        arrayVariable = [1, "2", "null", ]; // the literal list has an `array<any>` type
+        arrayVariable = [1, 2, 3]; // the literal list has an `array<int>` type
     }
 }

--- a/src/test/testdata/lsl/literalArrays.lsl
+++ b/src/test/testdata/lsl/literalArrays.lsl
@@ -1,0 +1,16 @@
+libsl "1.0.0";
+library literalArrays;
+
+typealias Int = int32;
+
+automaton A : Int {
+    fun f(param: Int) {
+      action TEST_ACTION([123]);
+      action TEST_ACTION([123, ]);
+      action TEST_ACTION([123, 321, ]);
+      action TEST_ACTION(["test string", param]);
+      action TEST_ACTION(["test string", param, ]);
+      action TEST_ACTION([]);
+      action TEST_ACTION([1+2+3]);
+    }
+}

--- a/src/test/testdata/lsl/literalArrays.lsl
+++ b/src/test/testdata/lsl/literalArrays.lsl
@@ -2,15 +2,23 @@ libsl "1.0.0";
 library literalArrays;
 
 typealias Int = int32;
+typealias ArrayType = array<Int>;
 
 automaton A : Int {
+    var arrayVariable: ArrayType;
+
     fun f(param: Int) {
-      action TEST_ACTION([123]);
-      action TEST_ACTION([123, ]);
-      action TEST_ACTION([123, 321, ]);
-      action TEST_ACTION(["test string", param]);
-      action TEST_ACTION(["test string", param, ]);
-      action TEST_ACTION([]);
-      action TEST_ACTION([1+2+3]);
+        action TEST_ACTION([123]);
+        action TEST_ACTION([123]);
+        action TEST_ACTION([123, 321]);
+        action TEST_ACTION(["test string", param]);
+        action TEST_ACTION(["test string", param]);
+        action TEST_ACTION([]);
+        action TEST_ACTION([((1 + 2) + 3)]);
+    }
+
+    fun g() {
+        arrayVariable = [1, "2", "null", ]; // the literal list has an `any` type
+        arrayVariable = [1, 2, 3]; // the literal list has an `int` type
     }
 }


### PR DESCRIPTION
1. I have added new parsing rules to extend expressions with literal arrays. Literal arrays can be used as expression so they can be used everywhere where expressions can;
2. Also, I have added `Any` type. This type is inferred by type inferrer when it gets two different types. So, `Int`+`String`=`Any` now. Previous behavior was `throw an exception` in this case. **To be discussed**
3. Type of an empty literal array is empty; when the parser will be extended for advanced type checking, `Nothing` type could be introduced. This move makes the next code valid:
```
typealias MyType = array<Int>
var v: MyType = [] // now, type([]) = Any and type mismatch situation is here
```
The error is not critical now because everything is parsing well