### PR TITLE
[REOPEN] Fix expressions dumping

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/libsl/nodes/helpers/ExpressionDumper.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/nodes/helpers/ExpressionDumper.kt
@@ -1,0 +1,175 @@
+package org.jetbrains.research.libsl.nodes.helpers
+
+import org.jetbrains.research.libsl.nodes.*
+import org.jetbrains.research.libsl.utils.BackticksPolitics
+
+object ExpressionDumper {
+    fun dump(expression: Expression): String = dump(expression, priority = Int.MAX_VALUE)
+
+    private fun dump(expression: Expression, priority: Int): String {
+        return when (expression) {
+            is BinaryOpExpression -> dumpBinaryExpression(expression, priority)
+            is ActionExpression -> dumpActionExpression(expression)
+            is ArrayLiteral -> dumpArrayLiteral(expression)
+            is BoolLiteral -> dumpLiteral(expression)
+            is CallAutomatonConstructor -> dumpCallAutomatonConstructor(expression)
+            is FloatLiteral -> dumpLiteral(expression)
+            is IntegerLiteral -> dumpLiteral(expression)
+            is ArrayAccess -> dumpArrayAccess(expression)
+            is AutomatonOfFunctionArgumentInvoke -> dumpAutomatonOfFunctionArgumentInvoke(expression)
+            is ThisAndParentAccess -> dumpThisAndParentAccess(expression)
+            is VariableAccess -> dumpVariableAccess(expression)
+            is StringLiteral -> dumpStringLiteral(expression)
+            is OldValue -> dumpOldValue(expression)
+            is ProcExpression -> dumpProcExpression(expression)
+            is ThisExpression -> dumpThisExpression(expression)
+            is UnaryOpExpression -> dumpUnaryOpExpression(expression)
+            is Variable -> dumpVariable(expression)
+        }
+    }
+
+    private fun dumpBinaryExpression(expression: BinaryOpExpression, parentPriority: Int): String {
+        return buildString {
+            val currentPriority = expression.op.priority
+            val addBrackets = currentPriority > parentPriority
+
+            if (addBrackets) {
+                append("(")
+            }
+
+            append(dump(expression.left, currentPriority))
+            append(IPrinter.SPACE)
+            append(expression.op.string)
+            append(IPrinter.SPACE)
+            append(dump(expression.right, currentPriority))
+
+            if (addBrackets) {
+                append(")")
+            }
+        }
+    }
+
+    private fun dumpActionExpression(expression: ActionExpression): String {
+        return buildString {
+            append("action ${BackticksPolitics.forIdentifier(expression.action.name)}(")
+            val args = expression.action.arguments.map { dump(it) }.toMutableList()
+            append(args.joinToString(separator = ", "))
+            append(")")
+        }
+    }
+
+    private fun dumpArrayLiteral(expression: ArrayLiteral): String {
+        return buildString {
+            append("[")
+            append(
+                expression.value.joinToString(separator = ", ", transform = ::dump)
+            )
+            append("]")
+        }
+    }
+
+    private fun dumpCallAutomatonConstructor(expression: CallAutomatonConstructor): String {
+        return buildString {
+            append("new ${BackticksPolitics.forPeriodSeparated(expression.automatonRef.name)}")
+
+            val formattedArgs = buildList {
+                add("state = ${BackticksPolitics.forIdentifier(expression.stateRef.name)}")
+                for (arg in expression.args) {
+                    add(arg.dumpToString())
+                }
+            }
+            append(formattedArgs.joinToString(separator = ", ", prefix = "(", postfix = ")"))
+        }
+    }
+
+    private fun dumpLiteral(expression: Atomic): String {
+        return expression.value.toString()
+    }
+
+    private fun dumpStringLiteral(expression: StringLiteral): String {
+        return "\"${expression.value}\""
+    }
+
+    private fun dumpArrayAccess(expression: ArrayAccess): String {
+        return buildString {
+            append("[${dump(expression.index)}]")
+            if (expression.childAccess != null) {
+                if (expression.childAccess is VariableAccess) {
+                    append(".")
+                }
+
+                append(dump(expression.childAccess!!))
+            }
+        }
+    }
+
+    private fun dumpAutomatonOfFunctionArgumentInvoke(expression: AutomatonOfFunctionArgumentInvoke): String {
+        return buildString {
+            append(BackticksPolitics.forPeriodSeparated(expression.automatonReference.name))
+            append("(")
+            append(BackticksPolitics.forIdentifier(expression.arg.name))
+            append(")")
+
+            if (expression.childAccess != null) {
+                append(".")
+                append(dump(expression.childAccess!!))
+            }
+        }
+    }
+
+    private fun dumpThisAndParentAccess(expression: ThisAndParentAccess): String {
+        return buildString {
+            if (expression.hasThisExpression) {
+                append("this.")
+            }
+            if (expression.hasParentExpression) {
+                append("parent.")
+            }
+            if (expression.childAccess != null) {
+                append(dump(expression.childAccess!!))
+            }
+        }
+    }
+
+    private fun dumpVariableAccess(expression: VariableAccess): String {
+        return when {
+            expression.childAccess != null && expression.childAccess is VariableAccess -> {
+                "${BackticksPolitics.forIdentifier(expression.fieldName)}.${dump(expression.childAccess!!)}"
+            }
+            expression.childAccess != null -> {
+                "${BackticksPolitics.forIdentifier(expression.fieldName)}${dump(expression.childAccess!!)}"
+            }
+            else -> expression.fieldName
+        }
+    }
+
+    private fun dumpOldValue(expression: OldValue): String {
+        return "(${dump(expression.value)})'"
+    }
+
+    private fun dumpThisExpression(expression: ThisExpression): String {
+        return buildString {
+            append("this")
+            if (expression.parentKeywordUsed) {
+                append(".parent")
+            }
+        }
+    }
+
+    private fun dumpProcExpression(expression: ProcExpression): String {
+        return buildString {
+            append("${BackticksPolitics.forIdentifier(expression.proc.name)}(")
+            val args = expression.proc.arguments.map { dump(it) }.toMutableList()
+            append(args.joinToString(separator = ", "))
+            append(")")
+        }
+    }
+
+    private fun dumpUnaryOpExpression(expression: UnaryOpExpression): String {
+        return "${expression.op.string}${dump(expression.value)}"
+    }
+
+    private fun dumpVariable(expression: Variable): String {
+        return expression.name
+    }
+}

--- a/src/main/kotlin/org/jetbrains/research/libsl/nodes/literals.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/nodes/literals.kt
@@ -10,9 +10,7 @@ data class FloatLiteral(
 
 data class StringLiteral(
     override val value: String
-) : Atomic() {
-    override fun dumpToString(): String = "\"$value\""
-}
+) : Atomic()
 
 data class BoolLiteral(
     override val value: Boolean

--- a/src/main/kotlin/org/jetbrains/research/libsl/nodes/meta.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/nodes/meta.kt
@@ -38,6 +38,7 @@ data class Library(
         append(formatDeclaredAnnotations())
         append(formatActionDeclarations())
         append(formatAutomata())
+        appendLine()
     }
 
     private fun formatImports(): String {

--- a/src/main/kotlin/org/jetbrains/research/libsl/nodes/qualifiedAccesses.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/nodes/qualifiedAccesses.kt
@@ -93,19 +93,6 @@ data class ArrayAccess(
 ) : QualifiedAccess() {
     override var childAccess: QualifiedAccess? = null
 
-    override fun toString(): String = dumpToString()
-
-    override fun dumpToString(): String = buildString {
-        append("[${index.dumpToString()}]")
-        if (childAccess != null) {
-            if (childAccess is VariableAccess) {
-                append(".")
-            }
-
-            append(childAccess!!.dumpToString())
-        }
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is ArrayAccess) return false
@@ -128,20 +115,6 @@ data class AutomatonOfFunctionArgumentInvoke(
     val arg: FunctionArgument,
     override var childAccess: QualifiedAccess?,
 ) : QualifiedAccess() {
-    override fun toString(): String = dumpToString()
-
-    override fun dumpToString(): String = buildString {
-        append(BackticksPolitics.forPeriodSeparated(automatonReference.name))
-        append("(")
-        append(BackticksPolitics.forIdentifier(arg.name))
-        append(")")
-
-        if (childAccess != null) {
-            append(".")
-            append(childAccess!!.dumpToString())
-        }
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is AutomatonOfFunctionArgumentInvoke) return false

--- a/src/main/kotlin/org/jetbrains/research/libsl/nodes/statements.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/nodes/statements.kt
@@ -3,6 +3,7 @@ package org.jetbrains.research.libsl.nodes
 import org.jetbrains.research.libsl.utils.BackticksPolitics
 
 sealed class Statement: Node()
+
 data class Assignment(
     val left: QualifiedAccess,
     val value: Expression
@@ -38,8 +39,8 @@ data class IfStatement(
     val elseStatements: ElseStatement?
 ) : Statement() {
     override fun dumpToString(): String = buildString {
-        append("if${value.dumpToString()}")
-        appendLine(" {")
+        append("if (${value.dumpToString()}) ")
+        appendLine("{")
         append(withIndent(formatListEmptyLineAtEndIfNeeded(ifStatements)))
         appendLine("}")
         elseStatements?.also {
@@ -57,7 +58,6 @@ data class ElseStatement(
     override fun dumpToString(): String = buildString {
         append(withIndent(formatListEmptyLineAtEndIfNeeded(statements)))
     }
-
 }
 
 data class Action(
@@ -100,7 +100,7 @@ data class ExpressionStatement(
     }
 }
 
-data class VariableStatement(
+data class VariableDeclaration(
     val variable: VariableWithInitialValue
 ) : Statement() {
     override fun dumpToString(): String = buildString {

--- a/src/main/kotlin/org/jetbrains/research/libsl/nodes/variables.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/nodes/variables.kt
@@ -94,21 +94,8 @@ class ActionParameter(
     name: String,
     typeReference: TypeReference,
     val index: Int,
-    var annotation: AnnotationReference? = null,
-
-    ) : Variable(keyword = VariableKeyword.ARGUMENT, name, typeReference) {
-
-    override fun dumpToString(): String = buildString {
-        if (annotation != null) {
-            append(annotation!!)
-            append(IPrinter.SPACE)
-        }
-        append(BackticksPolitics.forIdentifier(name))
-        append(": ")
-
-        append(typeReference.name)
-    }
-}
+    var annotation: AnnotationReference? = null
+) : Variable(keyword = VariableKeyword.ARGUMENT, name, typeReference)
 
 @Suppress("MemberVisibilityCanBePrivate")
 class DeclaredActionParameter(

--- a/src/main/kotlin/org/jetbrains/research/libsl/visitors/BlockStatementVisitor.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/visitors/BlockStatementVisitor.kt
@@ -3,7 +3,6 @@ package org.jetbrains.research.libsl.visitors
 import org.jetbrains.research.libsl.LibSLParser
 import org.jetbrains.research.libsl.context.FunctionContext
 import org.jetbrains.research.libsl.nodes.*
-import org.jetbrains.research.libsl.nodes.references.AnnotationReference
 
 class BlockStatementVisitor(
     private val functionContext: FunctionContext,
@@ -122,9 +121,9 @@ class BlockStatementVisitor(
             getAnnotationUsages(ctx.annotationUsage()),
             initValue
         )
-        val variableStatement = VariableStatement(variable)
+        val variableDeclaration = VariableDeclaration(variable)
         localVariables.add(variable)
-        statements.add(variableStatement)
+        statements.add(variableDeclaration)
         context.storeVariable(variable)
     }
 

--- a/src/test/kotlin/GeneratedTests.kt
+++ b/src/test/kotlin/GeneratedTests.kt
@@ -86,6 +86,11 @@ class GeneratedTests {
     }
 
     @Test
+    fun testExpressionsLsl() {
+        runLslTest("expressions")
+    }
+
+    @Test
     fun testFunctionAnnotationsLsl() {
         runLslTest("functionAnnotations")
     }

--- a/src/test/kotlin/testRunner.kt
+++ b/src/test/kotlin/testRunner.kt
@@ -114,7 +114,7 @@ private fun checkStatementIsResolved(function: Function, statements: List<Statem
             is Action -> {}
             is Proc -> {}
             // TODO(Variable statement)
-            is VariableStatement -> {}
+            is VariableDeclaration -> {}
             is Assignment -> {
                 function.context.typeInferrer.getExpressionType(statement.left)
                 function.context.typeInferrer.getExpressionType(statement.value)

--- a/src/test/testdata/expected/lsl/actions.lsl
+++ b/src/test/testdata/expected/lsl/actions.lsl
@@ -5,9 +5,9 @@ typealias Int = int32;
 
 automaton A : Int {
     var i: Int;
-    
+
     fun f(param: Int) {
-        action TEST_ACTION(1, "123", param, (1 + 123));
+        action TEST_ACTION(1, "123", param, 1 + 123);
         action TEST_ACTION_TWO("foo");
     }
 }

--- a/src/test/testdata/expected/lsl/automatonConstructor.lsl
+++ b/src/test/testdata/expected/lsl/automatonConstructor.lsl
@@ -5,13 +5,15 @@ types {
     Int(int32);
     String(string);
 }
+
 automaton A (var i: Int, var s: String) : Int {
     var i: Int;
-    
+
     fun func() {
-        i = new B(state = s1, v = ((1 + 1) / 2));
+        i = new B(state = s1, v = (1 + 1) / 2);
     }
 }
+
 automaton B (var v: Int) : Int {
     state s1;
 }

--- a/src/test/testdata/expected/lsl/contracts.lsl
+++ b/src/test/testdata/expected/lsl/contracts.lsl
@@ -1,12 +1,15 @@
 libsl "1.0.0";
 library simple;
+
 types {
     Int(int32);
 }
+
 automaton A : Int {
     var i: Int;
+
     fun f(param: Int): Int {
-        requires test1: (param >= i);
-        ensures ((param' < param) & (result == 1));
+        requires test1: param >= i;
+        ensures (param)' < param & result == 1;
     }
 }

--- a/src/test/testdata/expected/lsl/equalsAndAssign.lsl
+++ b/src/test/testdata/expected/lsl/equalsAndAssign.lsl
@@ -1,9 +1,11 @@
 libsl "1.0.0";
 library simple;
+
 typealias Int = int32;
 typealias boolean = bool;
+
 automaton A : Int {
     fun foo(x: Int, y: Int): boolean {
-        result = (x == y);
+        result = x == y;
     }
 }

--- a/src/test/testdata/expected/lsl/escapingTest.lsl
+++ b/src/test/testdata/expected/lsl/escapingTest.lsl
@@ -12,6 +12,7 @@ automaton A : Int {
     fun `<test>`(): Int {
     }
 }
+
 automaton `123` : Int {
     initstate Init;
 }

--- a/src/test/testdata/expected/lsl/expressions.lsl
+++ b/src/test/testdata/expected/lsl/expressions.lsl
@@ -1,0 +1,17 @@
+libsl "1.0.0";
+library expressions;
+
+typealias Int = int32;
+
+automaton A : Int {
+    var tmp: Int;
+
+    fun f(param: Int) {
+        tmp = 2 + 3;
+        tmp = 2 + 3 + 4;
+        tmp = (2 + 3) / 4;
+        tmp = (2 + 3 + 4) / 5;
+        tmp = 10 + 14 * (2 + 1);
+        tmp = 10 + 14 / (2 + 1);
+    }
+}

--- a/src/test/testdata/expected/lsl/functionAnnotations.lsl
+++ b/src/test/testdata/expected/lsl/functionAnnotations.lsl
@@ -1,16 +1,24 @@
 libsl "1.0.0";
 library simple;
+
 typealias Int = int32;
+
 annotation Static;
+
 annotation Void;
+
 annotation Anno(
     x: Int,
     y: Int
 );
+
 annotation Target;
+
 annotation Something;
+
 automaton B : Int {
 }
+
 automaton A : Int {
     @Static
     fun f(@Anno(1, 12) @Target obj: B);

--- a/src/test/testdata/expected/lsl/globalVariables.lsl
+++ b/src/test/testdata/expected/lsl/globalVariables.lsl
@@ -4,6 +4,7 @@ library simple;
 types {
     Int(int32);
 }
+
 var globalInt: Int = new A(state = S);
 
 automaton A : Int {

--- a/src/test/testdata/expected/lsl/ifElse.lsl
+++ b/src/test/testdata/expected/lsl/ifElse.lsl
@@ -1,10 +1,13 @@
 libsl "1.0.0";
 library simple;
+
 typealias Int = int32;
+
 automaton A : Int {
     var result: Int;
+
     fun f(x: Int, y: Int) {
-        if(x == y) {
+        if (x == y) {
             result = x;
         }
         else {

--- a/src/test/testdata/expected/lsl/internalVariables.lsl
+++ b/src/test/testdata/expected/lsl/internalVariables.lsl
@@ -4,15 +4,15 @@ library simple;
 types {
     Int(int32);
 }
+
 automaton A : Int {
     var b: Int = new B(state = s);
-    
     fun foo() {
         b = 1;
     }
 }
+
 automaton B : Int {
     state s;
     var i: Int;
-    
 }

--- a/src/test/testdata/expected/lsl/literalArrays.lsl
+++ b/src/test/testdata/expected/lsl/literalArrays.lsl
@@ -1,9 +1,12 @@
 libsl "1.0.0";
 library literalArrays;
+
 typealias Int = int32;
 typealias ArrayType = array<Int>;
+
 automaton A : Int {
     var arrayVariable: ArrayType;
+
     fun f(param: Int) {
         action TEST_ACTION([123]);
         action TEST_ACTION([123]);
@@ -11,8 +14,9 @@ automaton A : Int {
         action TEST_ACTION(["test string", param]);
         action TEST_ACTION(["test string", param]);
         action TEST_ACTION([]);
-        action TEST_ACTION([((1 + 2) + 3)]);
+        action TEST_ACTION([1 + 2 + 3]);
     }
+
     fun g() {
         arrayVariable = ["1", "2", "null"];
         arrayVariable = [1, 2, 3];

--- a/src/test/testdata/expected/lsl/multipleFromInShift.lsl
+++ b/src/test/testdata/expected/lsl/multipleFromInShift.lsl
@@ -1,8 +1,10 @@
 libsl "1.0.0";
 library simple;
+
 types {
     Int(int32);
 }
+
 automaton A : Int {
     state s1;
     state s2;

--- a/src/test/testdata/expected/lsl/newVariables.lsl
+++ b/src/test/testdata/expected/lsl/newVariables.lsl
@@ -1,15 +1,19 @@
 libsl "1.0.0";
 library simple;
+
 types {
     Int(int32);
 }
+
 automaton A (val x: Int) : Int {
     val y: Int;
     fun f(param: Int) {
-        requires (i == 0);
+        requires i == 0;
+
         val x: Int = 1;
         val v: Int;
-        if(y > 1) {
+
+        if (y > 1) {
             val b: Int;
         }
     }

--- a/src/test/testdata/expected/lsl/operators.lsl
+++ b/src/test/testdata/expected/lsl/operators.lsl
@@ -1,16 +1,18 @@
 libsl "1.0.0";
 library simple;
+
 types {
     Int(int32);
 }
+
 automaton A : Int {
     fun f(x: Int, y: Int) {
         ++x;
         x++;
         --x;
         x--;
-        x = (x && y);
-        x = (x || y);
+        x = x && y;
+        x = x || y;
         y = !x;
         x += y;
         x -= y;

--- a/src/test/testdata/expected/lsl/primitiveTypes.lsl
+++ b/src/test/testdata/expected/lsl/primitiveTypes.lsl
@@ -2,12 +2,11 @@ libsl "1.0.0";
 library simple;
 
 typealias Int = int32;
-
 typealias V = *void;
 
 automaton A : Int {
     var i: V;
-    
+
     fun f(param: Int): V {
     }
 }

--- a/src/test/testdata/expected/lsl/proc.lsl
+++ b/src/test/testdata/expected/lsl/proc.lsl
@@ -1,14 +1,19 @@
 libsl "1.0.0";
 library simple;
+
 typealias Int = int32;
+
 automaton A : Int {
     val x: Int = 1;
     val y: Int = 2;
+
     proc _sum(x: Int, y: Int): Int {
-        result = (x + y);
+        result = x + y;
     }
+
     proc _noReturn() {
     }
+
     fun useProc(): Int {
         _noReturn();
         result = _sum(x, y);

--- a/src/test/testdata/expected/lsl/this.lsl
+++ b/src/test/testdata/expected/lsl/this.lsl
@@ -1,19 +1,23 @@
 libsl "1.0.0";
 library simple;
+
 types {
     Int(int32);
 }
+
 automaton A (val v: Int) : Int {
     proc smth(): Int {
-        result = (1 + 1);
+        result = 1 + 1;
     }
 }
+
 automaton B (val x: Int) : Int {
     fun foo(arg: Int): Int {
         assigns this.parent;
         val y: Int = this.parent.v;
-        result = (this.x + y);
+        result = this.x + y;
     }
+
     fun anotherFoo() {
         this.parent.smth();
     }

--- a/src/test/testdata/expected/lsl/types.lsl
+++ b/src/test/testdata/expected/lsl/types.lsl
@@ -1,19 +1,24 @@
 libsl "1.0.0";
 library simple;
+
 enum foo.vldf.Type {
     Variant1 = 0;
     Variant2 = 1;
 }
+
 typealias MyType = foo.vldf.Type;
+
 type StructureType {
     field: Int;
 }
+
 type BlackAndWhiteImage {
     height: Int;
     width: Int;
     tpe: StructureType;
     content: array<array<Boolean>>;
 }
+
 types {
     Int(int32);
     Type(Int) {
@@ -21,10 +26,12 @@ types {
         variant2: 1;
     }
 }
+
 automaton Image : BlackAndWhiteImage {
     fun inversePixel(img: BlackAndWhiteImage, x: Int, y: Int) {
-        requires size: ((x > 0) & (y > 0));
-        ensures (img.content[y][x] != img.content[y][x]');
+        requires size: x > 0 & y > 0;
+        ensures img.content[y][x] != (img.content[y][x])';
+
         img.content[y][x] = !img.content[y][x];
         img.tpe.field = 1;
     }

--- a/src/test/testdata/expected/lsl/variableAnnotations.lsl
+++ b/src/test/testdata/expected/lsl/variableAnnotations.lsl
@@ -1,22 +1,30 @@
 libsl "1.0.0";
 library simple;
+
 types {
     Int(int32);
 }
+
 @Const
 var x: Int = 1;
+
 annotation Const;
+
 annotation Something;
+
 automaton A (@Something var y: Int) : Int {
     @Something
     var i: Int;
+
     fun f(param: Int) {
-        requires (i == 0);
+        requires i == 0;
         i = 1;
     }
+
     fun g(a: Int) {
         i = a;
     }
+
     fun a(i: Int) {
         i = 0;
     }

--- a/src/test/testdata/expected/lsl/variableResolution.lsl
+++ b/src/test/testdata/expected/lsl/variableResolution.lsl
@@ -1,17 +1,22 @@
 libsl "1.0.0";
 library simple;
+
 types {
     Int(int32);
 }
+
 automaton A : Int {
     var i: Int;
+
     fun f(param: Int) {
-        requires (i == 0);
+        requires i == 0;
         i = 1;
     }
+
     fun g(a: Int) {
         i = a;
     }
+
     fun a(i: Int) {
         i = 0;
     }

--- a/src/test/testdata/lsl/expressions.lsl
+++ b/src/test/testdata/lsl/expressions.lsl
@@ -1,0 +1,20 @@
+libsl "1.0.0";
+library expressions;
+
+typealias Int = int32;
+
+automaton A : Int {
+    var tmp: Int;
+
+    fun f(param: Int) {
+      tmp = 2 + 3;
+      tmp = 2 + 3 + 4;
+      tmp = (2 + 3) / 4;
+      tmp = (2 + 3 + 4) / 5;
+      tmp = 10 + 14 * (2 + 1);
+      tmp = 10 + 14 / (2 + 1);
+// todo: fix when <<, >> and >>> operations will be fixed
+//      tmp = 10 << 2;
+//      tmp = (10 << 2) + 14;
+    }
+}


### PR DESCRIPTION
There was an old issue about binary expressions dumping result: some redundant brackets used to add. In this PR I introduce the new approach to avoid this issue

Previously generated expression examle:
```
((2+(3+(4)))/2)
```

Currently generated expression example:
```
(2+3+4)/2
```

Now I understand that our old approach of placing everything about a node in the same class is terrible. We violate the single responsibility principle. So, this PR is the first step to improve our architecture and make the code more agile.

NB: This PR contains some commits from https://github.com/vpa-research/libsl-parser/pull/8; review and accept the previous one first (and repeating commits will disappear)