### PR TITLE
Trying to fix automata functions resolve

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/libsl/visitors/FunctionVisitor.kt
+++ b/src/main/kotlin/org/jetbrains/research/libsl/visitors/FunctionVisitor.kt
@@ -97,6 +97,7 @@ class FunctionVisitor(
 
         super.visitFunctionDecl(ctx)
         parentAutomaton?.localFunctions?.add(buildingFunction)
+        context.parentContext?.storeFunction(buildingFunction)
     }
 
     override fun visitConstructorDecl(ctx: ConstructorDeclContext) {


### PR DESCRIPTION
When iterating through automaton's shifts and inspecting their `functions` property you get a list of references to functions. But resolving these references didn't work because automaton's context weren't filled with automaton's function. I'm adding functions to the context in this change